### PR TITLE
`berks install --path [PATH}` has been replaced by `berks vendor`

### DIFF
--- a/resolver/berkshelf/resolver.go
+++ b/resolver/berkshelf/resolver.go
@@ -3,6 +3,9 @@
 package berkshelf
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/mlafeldt/chef-runner/exec"
 	"github.com/mlafeldt/chef-runner/util"
 )
@@ -16,7 +19,16 @@ func Command(dst string) []string {
 	if util.FileExist("Gemfile") {
 		cmd = []string{"bundle", "exec"}
 	}
-	cmd = append(cmd, "berks", "vendor", dst)
+
+	code := []string{
+		`require "berkshelf";`,
+		`b = Berkshelf::Berksfile.from_file("Berksfile");`,
+		`Berkshelf::Berksfile.method_defined?(:vendor)`, `?`,
+		fmt.Sprintf(`b.vendor("%s")`, dst), `:`,
+		fmt.Sprintf(`b.install(:path => "%s")`, dst),
+	}
+
+	cmd = append(cmd, "ruby", "-e", strings.Join(code, " "))
 	return cmd
 }
 

--- a/resolver/berkshelf/resolver_test.go
+++ b/resolver/berkshelf/resolver_test.go
@@ -2,6 +2,7 @@ package berkshelf_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mlafeldt/chef-runner/resolver/berkshelf"
@@ -9,9 +10,10 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	expect := []string{"berks", "vendor", "a/b/c"}
-	actual := berkshelf.Command("a/b/c")
-	assert.Equal(t, expect, actual)
+	cmd := berkshelf.Command("a/b/c")
+	assert.Equal(t, []string{"ruby", "-e"}, cmd[:2])
+	assert.True(t, strings.Contains(cmd[2], `require "berkshelf"`))
+	assert.True(t, strings.Contains(cmd[2], `.vendor("a/b/c")`))
 }
 
 func TestCommand_Bundler(t *testing.T) {
@@ -19,7 +21,8 @@ func TestCommand_Bundler(t *testing.T) {
 	f.Close()
 	defer os.Remove("Gemfile")
 
-	expect := []string{"bundle", "exec", "berks", "vendor", "a/b/c"}
-	actual := berkshelf.Command("a/b/c")
-	assert.Equal(t, expect, actual)
+	cmd := berkshelf.Command("a/b/c")
+	assert.Equal(t, []string{"bundle", "exec", "ruby", "-e"}, cmd[:4])
+	assert.True(t, strings.Contains(cmd[4], `require "berkshelf"`))
+	assert.True(t, strings.Contains(cmd[4], `.vendor("a/b/c")`))
 }

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,8 +1,10 @@
 package resolver_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mlafeldt/chef-runner/exec"
@@ -58,7 +60,10 @@ func TestAutoResolve_Berkshelf(t *testing.T) {
 		assert.NoError(t, resolver.AutoResolve(CookbookPath))
 	})
 
-	assert.Equal(t, []string{"berks", "vendor", CookbookPath}, lastCmd)
+	assert.Equal(t, []string{"ruby", "-e"}, lastCmd[:2])
+	assert.True(t, strings.Contains(lastCmd[2], `require "berkshelf"`))
+	assert.True(t, strings.Contains(lastCmd[2],
+		fmt.Sprintf(`.vendor("%s")`, CookbookPath)))
 }
 
 func TestAutoResolve_Librarian(t *testing.T) {


### PR DESCRIPTION
Berkshelf switched commands from `berks install --path [PATH}` to `berks vendor`.

```
INFO: Installing cookbook dependencies with Berkshelf resolver
DEPRECATED: `berks install --path [PATH}` has been replaced by `berks vendor`.
DEPRECATED: Re-run your command as `berks vendor [PATH]` or see `berks help vendor`.
```
