### PR TITLE
Stop running Rsync in verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ FEATURES:
   `ssh_config(5)` for a list of available options and their format. (Thanks to
   @berniedurfee who requested this feature.)
 * Allow to specify one or more custom Rsync options on the command line, e.g.
-  `chef-runner --rsync-option "--progress"`. See `rsync(1)` for a list of
+  `chef-runner --rsync-option --progress`. See `rsync(1)` for a list of
   available options.
 * Add `--color=false` option to disable colorized output.
 
@@ -30,6 +30,8 @@ BREAKING CHANGES:
   expanded to `<cookbook>::foo`. Local recipes now need to be passed as `::foo`
   instead. This change also simplifies run list composition when multiple
   cookbooks are involved, e.g. `chef-runner apt postgresql::client nginx`.
+* No longer run Rsync in verbose mode by default. To get back the old output,
+  you need to use `--rsync-option --verbose` now.
 
 [omnibus package]: https://godoc.org/github.com/mlafeldt/chef-runner/chef/omnibus
 

--- a/driver/kitchen/driver_test.go
+++ b/driver/kitchen/driver_test.go
@@ -16,7 +16,7 @@ func TestDriverInterface(t *testing.T) {
 func TestNewDriver(t *testing.T) {
 	util.InDir("../../testdata", func() {
 		sshOpts := []string{"LogLevel=debug"}
-		rsyncOpts := []string{"--quiet"}
+		rsyncOpts := []string{"--verbose"}
 		drv, err := NewDriver("default-ubuntu-1404", sshOpts, rsyncOpts)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "127.0.0.1", drv.SSHClient.Host)

--- a/driver/ssh/driver_test.go
+++ b/driver/ssh/driver_test.go
@@ -14,7 +14,7 @@ func TestDriverInterface(t *testing.T) {
 
 func TestNewDriver(t *testing.T) {
 	sshOpts := []string{"LogLevel=debug"}
-	rsyncOpts := []string{"--quiet"}
+	rsyncOpts := []string{"--verbose"}
 	drv, err := NewDriver("some-user@some-host:1234", sshOpts, rsyncOpts)
 	if assert.NoError(t, err) {
 		assert.Equal(t, "some-host", drv.SSHClient.Host)

--- a/driver/vagrant/driver_test.go
+++ b/driver/vagrant/driver_test.go
@@ -23,7 +23,7 @@ func TestNewDriver(t *testing.T) {
 		defer os.Setenv("PATH", oldPath)
 
 		sshOpts := []string{"LogLevel=debug"}
-		rsyncOpts := []string{"--quiet"}
+		rsyncOpts := []string{"--verbose"}
 		drv, err := NewDriver("some-machine", sshOpts, rsyncOpts)
 		if assert.NoError(t, err) {
 			defer os.RemoveAll(".chef-runner")

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -63,7 +63,7 @@ func TestAutoResolve_Dir(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"rsync", "--archive", "--delete", "--compress",
-		"--verbose", "metadata.rb", CookbookPath + "/cats"}, lastCmd)
+		"metadata.rb", CookbookPath + "/cats"}, lastCmd)
 }
 
 func TestAutoResolve_DirUpdate(t *testing.T) {
@@ -78,7 +78,7 @@ func TestAutoResolve_DirUpdate(t *testing.T) {
 	})
 
 	assert.Equal(t, []string{"rsync", "--archive", "--delete", "--compress",
-		"--verbose", "metadata.rb", CookbookPath + "/cats"}, lastCmd)
+		"metadata.rb", CookbookPath + "/cats"}, lastCmd)
 }
 
 func TestAutoResolve_NoCookbooks(t *testing.T) {

--- a/rsync/rsync.go
+++ b/rsync/rsync.go
@@ -43,7 +43,6 @@ var MirrorClient = &Client{
 	Archive:  true,
 	Delete:   true,
 	Compress: true,
-	Verbose:  true,
 }
 
 // Command returns the rsync command that will be executed by Copy.


### PR DESCRIPTION
It's just too verbose.

To get back the old output, you need to use `--rsync-option --verbose` now.
