### PR TITLE
Build infrastructure for Debian packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@
 * Embed Omnibus installer instead of downloading it from the Internet. Now the
   script [is part][install.sh] of chef-runner's source code and we have total
   control of what it does.
-* On Ubuntu, you can now install chef-runner from a [Debian package][deb].
+* You can now install chef-runner as a Debian package on most Ubuntu and Debian
+  distributions. See the [wiki page][deb] to learn more.
 * Add `Makefile`.
 
 [wiki]: https://github.com/mlafeldt/chef-runner/wiki
 [install.sh]: /chef/omnibus/assets/install.sh
-[deb]: https://packagecloud.io/mlafeldt/chef-runner?filter=debs
+[deb]: https://github.com/mlafeldt/chef-runner/wiki/Installation
 
 ## v0.8.0 (Nov 16 2014)
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ build:
 release:
 	@script/build --release
 
+deb:
+	$(MAKE) -C packaging/debian build
+
 clean:
 	$(RM) -r .cover build
 
-.PHONY: all bootstrap generate update_omnibus lint test coverage build release
+.PHONY: all bootstrap generate update_omnibus \
+	lint test coverage build release deb clean

--- a/packaging/debian/.dockerignore
+++ b/packaging/debian/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/packaging/debian/.gitignore
+++ b/packaging/debian/.gitignore
@@ -1,0 +1,4 @@
+cache/
+pkg/
+tmp-build/
+tmp-dest/

--- a/packaging/debian/.gitignore
+++ b/packaging/debian/.gitignore
@@ -1,4 +1,4 @@
-cache/
-pkg/
-tmp-build/
-tmp-dest/
+cache
+pkg
+tmp-build
+tmp-dest

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -1,0 +1,31 @@
+#
+# Docker image to build Debian package of chef-runner using fpm-cookery.
+#
+
+FROM ubuntu:14.04
+
+MAINTAINER Mathias Lafeldt <mathias.lafeldt@gmail.com>
+
+ENV REFRESHED_AT 2015-01-26
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        git \
+        ruby \
+        ruby-dev
+
+RUN echo "gem: --no-ri --no-rdoc" >/etc/gemrc
+RUN gem install fpm -v 1.3.3
+RUN gem install fpm-cookery -v 0.25.0
+
+# Install recent version of Go. Use --no-deps below to not install Go again.
+RUN curl -Ls https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz | \
+    tar -C /usr/local -xz
+ENV PATH=$PATH:/usr/local/go/bin
+
+VOLUME /data
+WORKDIR /data
+
+CMD ["fpm-cook", "package", "--debug", "--no-deps", "recipe.rb"]

--- a/packaging/debian/Makefile
+++ b/packaging/debian/Makefile
@@ -1,11 +1,10 @@
 #
 # Build Debian package of chef-runner and push it to packagecloud.io for all
-# supported Debian/Ubuntu distributions. All using Docker containers.
+# supported Debian/Ubuntu distributions.
 #
 
-CHEF_RUNNER_IMAGE  = mlafeldt/chef-runner:ubuntu
-PACKAGECLOUD_IMAGE = mlafeldt/packagecloud
-PACKAGECLOUD_REPO  = mlafeldt/chef-runner
+CHEF_RUNNER_IMAGE = mlafeldt/chef-runner:ubuntu
+PACKAGECLOUD_REPO = mlafeldt/chef-runner
 
 DISTROS = ubuntu/precise ubuntu/trusty ubuntu/utopic \
           debian/squeeze debian/wheezy debian/jessie
@@ -21,17 +20,15 @@ build: image
 push:
 	@for distro in $(DISTROS); do \
 		echo "Pushing package for $$distro..."; \
-		docker run -it --rm -v $(CURDIR)/pkg:/pkg:ro \
-			-e PACKAGECLOUD_TOKEN=$(PACKAGECLOUD_TOKEN) $(PACKAGECLOUD_IMAGE) \
-			/bin/bash -c "package_cloud push $(PACKAGECLOUD_REPO)/$$distro /pkg/*.deb" || exit 1; \
+		package_cloud push $(PACKAGECLOUD_REPO)/$$distro pkg/*.deb || exit 1; \
 	done
 
 release: build push
 
 clean:
-	$(RM) -r cache/ tmp-build/ tmp-dest/
+	$(RM) -r cache tmp-build tmp-dest
 
 clobber: clean
-	$(RM) -r pkg/
+	$(RM) -r pkg
 
 .PHONY: all image build push release clean clobber

--- a/packaging/debian/Makefile
+++ b/packaging/debian/Makefile
@@ -1,0 +1,37 @@
+#
+# Build Debian package of chef-runner and push it to packagecloud.io for all
+# supported Debian/Ubuntu distributions. All using Docker containers.
+#
+
+CHEF_RUNNER_IMAGE  = mlafeldt/chef-runner:ubuntu
+PACKAGECLOUD_IMAGE = mlafeldt/packagecloud
+PACKAGECLOUD_REPO  = mlafeldt/chef-runner
+
+DISTROS = ubuntu/precise ubuntu/trusty ubuntu/utopic \
+          debian/squeeze debian/wheezy debian/jessie
+
+all: build
+
+image:
+	docker build --force-rm -t $(CHEF_RUNNER_IMAGE) $(CURDIR)
+
+build: image
+	docker run -it --rm -v $(CURDIR):/data $(CHEF_RUNNER_IMAGE)
+
+push:
+	@for distro in $(DISTROS); do \
+		echo "Pushing package for $$distro..."; \
+		docker run -it --rm -v $(CURDIR)/pkg:/pkg:ro \
+			-e PACKAGECLOUD_TOKEN=$(PACKAGECLOUD_TOKEN) $(PACKAGECLOUD_IMAGE) \
+			/bin/bash -c "package_cloud push $(PACKAGECLOUD_REPO)/$$distro /pkg/*.deb" || exit 1; \
+	done
+
+release: build push
+
+clean:
+	$(RM) -r cache/ tmp-build/ tmp-dest/
+
+clobber: clean
+	$(RM) -r pkg/
+
+.PHONY: all image build push release clean clobber

--- a/packaging/debian/recipe.rb
+++ b/packaging/debian/recipe.rb
@@ -1,0 +1,36 @@
+class ChefRunner < FPM::Cookery::Recipe
+  GOPACKAGE = "github.com/mlafeldt/chef-runner"
+
+  name     "chef-runner"
+  version  "0.8.0"
+  revision 2
+  source   "https://#{GOPACKAGE}/archive/v#{version}.tar.gz"
+  sha256   "a7de23f989f8353ecf838b551a8ceff09b83c8aeff2553b2c31d57615f8fcc53"
+
+  description "The fastest way to run Chef cookbooks"
+  homepage    "https://#{GOPACKAGE}"
+  maintainer  "Mathias Lafeldt <mathias.lafeldt@gmail.com>"
+  license     "Apache 2.0"
+  section     "development"
+
+  build_depends %w(golang-go git)
+
+  def build
+    pkgdir = builddir("gobuild/src/#{GOPACKAGE}")
+    mkdir_p pkgdir
+    cp_r Dir["*"], pkgdir
+
+    ENV["GOPATH"] = [
+      builddir("gobuild/src/#{GOPACKAGE}/Godeps/_workspace"),
+      builddir("gobuild"),
+    ].join(":")
+
+    safesystem "go version"
+    safesystem "go env"
+    safesystem "go get -v #{GOPACKAGE}/..."
+  end
+
+  def install
+    bin.install builddir("gobuild/bin/chef-runner")
+  end
+end


### PR DESCRIPTION
This uses Docker to first build a Debian package of chef-runner and then push it to https://packagecloud.io for all supported Ubuntu/Debian distributions:

* Ubuntu Precise (12.04 LTS)
* Ubuntu Trusty (14.04 LTS)
* Ubuntu Utopic (14.10)
* Debian Squeeze
* Debian Wheezy
* Debian Jessie

The resulting packages: https://packagecloud.io/mlafeldt/chef-runner

Wiki: https://github.com/mlafeldt/chef-runner/wiki/Installation#ubuntu--debian