### PR TITLE
Enable packaging with packager.io

### DIFF
--- a/.godir
+++ b/.godir
@@ -1,0 +1,1 @@
+chef-runner

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,7 @@
+cli: chef-runner
+targets:
+  debian-7:
+  ubuntu-12.04:
+  ubuntu-14.04:
+  centos-6:
+  fedora-20:


### PR DESCRIPTION
Not sure if you'd be interested, but you can enable automatic RPM and DEB packaging directly from this GitHub repository, using https://packager.io and the configuration provided in this PR.

I launched the packaging process on my branch for all distributions and it went fine: https://packager.io/gh/pkgr/chef-runner/install?bid=4#centos-6-chef-runner. Execution also appears to be fine, though I haven't tested anything other than:

```bash
$ chef-runner --version
chef-runner v0.9.0.dev linux/amd64 go1.4.1
```

Let me know what you think!