### PR TITLE
Add option to disable use of sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   Available resolvers are: `berkshelf`, `librarian`, and `dir`. Without this
   option, the resolver is still selected based on the files in the current
   directory.
+* Add `--sudo=false` option to not run commands using `sudo`. This currently
+  affects Omnibus installer and Chef itself.
 * Embed Omnibus installer instead of downloading it from the Internet. Now the
   script [is part][install.sh] of chef-runner's source code and we have total
   control of what it does.

--- a/chef/omnibus/omnibus.go
+++ b/chef/omnibus/omnibus.go
@@ -16,6 +16,7 @@ type Installer struct {
 	ChefVersion string
 	SandboxPath string
 	RootPath    string
+	Sudo        bool
 }
 
 func (i Installer) skip() bool {
@@ -61,11 +62,14 @@ func (i Installer) Command() []string {
 	if i.skip() {
 		return []string{}
 	}
-	return []string{
-		"sudo",
+	cmd := []string{
 		"sh",
 		path.Join(i.RootPath, "install-wrapper.sh"),
 		path.Join(i.RootPath, "install.sh"),
 		i.ChefVersion,
 	}
+	if !i.Sudo {
+		return cmd
+	}
+	return append([]string{"sudo"}, cmd...)
 }

--- a/chef/omnibus/omnibus_test.go
+++ b/chef/omnibus/omnibus_test.go
@@ -29,7 +29,11 @@ func TestCommand(t *testing.T) {
 		"1.2.3":  []string{"sudo", "sh", "/some/path/install-wrapper.sh", "/some/path/install.sh", "1.2.3"},
 	}
 	for version, cmd := range tests {
-		i := Installer{ChefVersion: version, RootPath: "/some/path"}
+		i := Installer{
+			ChefVersion: version,
+			RootPath:    "/some/path",
+			Sudo:        true,
+		}
 		assert.Equal(t, cmd, i.Command())
 	}
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -32,7 +32,9 @@ var usage = `Usage: chef-runner [options] [--] [<recipe>...]
                                default: info
   -j, --json-attributes <file> Load attributes from a JSON file
 
+  --sudo=false                 Do not run commands with sudo (enabled by default)
   --color=false                Disable colorized output (enabled by default)
+
   -h, --help                   Show help text
   --version                    Show program version
 `
@@ -67,7 +69,9 @@ type Flags struct {
 	JSONFile string
 	Recipes  []string
 
-	Color       bool
+	Sudo  bool
+	Color bool
+
 	ShowVersion bool
 }
 
@@ -104,6 +108,8 @@ func ParseFlags(args []string) (*Flags, error) {
 
 	f.StringVar(&flags.JSONFile, "j", "", "")
 	f.StringVar(&flags.JSONFile, "json-attributes", "", "")
+
+	f.BoolVar(&flags.Sudo, "sudo", true, "")
 
 	f.BoolVar(&flags.Color, "color", true, "")
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -17,87 +17,91 @@ func TestParseFlags(t *testing.T) {
 	}{
 		{
 			args:  []string{},
-			flags: &Flags{Color: true},
+			flags: &Flags{Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"-H", "some-host"},
-			flags: &Flags{Host: "some-host", Color: true},
+			flags: &Flags{Host: "some-host", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--host", "some-host"},
-			flags: &Flags{Host: "some-host", Color: true},
+			flags: &Flags{Host: "some-host", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"-M", "some-machine"},
-			flags: &Flags{Machine: "some-machine", Color: true},
+			flags: &Flags{Machine: "some-machine", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--machine", "some-machine"},
-			flags: &Flags{Machine: "some-machine", Color: true},
+			flags: &Flags{Machine: "some-machine", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"-K", "some-instance"},
-			flags: &Flags{Kitchen: "some-instance", Color: true},
+			flags: &Flags{Kitchen: "some-instance", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--kitchen", "some-instance"},
-			flags: &Flags{Kitchen: "some-instance", Color: true},
+			flags: &Flags{Kitchen: "some-instance", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--ssh", "x=1", "--ssh", "y 2 3"},
-			flags: &Flags{SSHOptions: []string{"x=1", "y 2 3"}, Color: true},
+			flags: &Flags{SSHOptions: []string{"x=1", "y 2 3"}, Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--rsync", "-x", "--rsync", "--y"},
-			flags: &Flags{RsyncOptions: []string{"-x", "--y"}, Color: true},
+			flags: &Flags{RsyncOptions: []string{"-x", "--y"}, Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--resolver", "some-resolver"},
-			flags: &Flags{Resolver: "some-resolver", Color: true},
+			flags: &Flags{Resolver: "some-resolver", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"-i", "1.2.3"},
-			flags: &Flags{ChefVersion: "1.2.3", Color: true},
+			flags: &Flags{ChefVersion: "1.2.3", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--install-chef", "1.2.3"},
-			flags: &Flags{ChefVersion: "1.2.3", Color: true},
+			flags: &Flags{ChefVersion: "1.2.3", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"-F", "some-format"},
-			flags: &Flags{Format: "some-format", Color: true},
+			flags: &Flags{Format: "some-format", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--format", "some-format"},
-			flags: &Flags{Format: "some-format", Color: true},
+			flags: &Flags{Format: "some-format", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"-l", "some-level"},
-			flags: &Flags{LogLevel: "some-level", Color: true},
+			flags: &Flags{LogLevel: "some-level", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--log_level", "some-level"},
-			flags: &Flags{LogLevel: "some-level", Color: true},
+			flags: &Flags{LogLevel: "some-level", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"-j", "some-file"},
-			flags: &Flags{JSONFile: "some-file", Color: true},
+			flags: &Flags{JSONFile: "some-file", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"--json-attributes", "some-file"},
-			flags: &Flags{JSONFile: "some-file", Color: true},
+			flags: &Flags{JSONFile: "some-file", Sudo: true, Color: true},
 		},
 		{
 			args:  []string{"some-recipe", "another-recipe"},
-			flags: &Flags{Recipes: []string{"some-recipe", "another-recipe"}, Color: true},
+			flags: &Flags{Recipes: []string{"some-recipe", "another-recipe"}, Sudo: true, Color: true},
+		},
+		{
+			args:  []string{"--sudo=false"},
+			flags: &Flags{Sudo: false, Color: true},
 		},
 		{
 			args:  []string{"--color=false"},
-			flags: &Flags{Color: false},
+			flags: &Flags{Sudo: true, Color: false},
 		},
 		{
 			args:  []string{"--version"},
-			flags: &Flags{ShowVersion: true, Color: true},
+			flags: &Flags{ShowVersion: true, Sudo: true, Color: true},
 		},
 		{
 			args: []string{"--machine", "some-machine", "-l", "some-level", "-i", "true", "some-recipe"},
@@ -106,6 +110,7 @@ func TestParseFlags(t *testing.T) {
 				ChefVersion: "true",
 				LogLevel:    "some-level",
 				Recipes:     []string{"some-recipe"},
+				Sudo:        true,
 				Color:       true,
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -127,14 +127,13 @@ func main() {
 
 	var p provisioner.Provisioner
 	p = chefsolo.Provisioner{
-		RunList:    runList,
-		Attributes: attributes,
-		Format:     flags.Format,
-		LogLevel:   flags.LogLevel,
-		UseSudo:    true,
-
+		RunList:     runList,
+		Attributes:  attributes,
+		Format:      flags.Format,
+		LogLevel:    flags.LogLevel,
 		SandboxPath: SandboxPath,
 		RootPath:    RootPath,
+		Sudo:        flags.Sudo,
 	}
 	log.Debugf("Provisioner = %+v\n", p)
 
@@ -142,6 +141,7 @@ func main() {
 		ChefVersion: flags.ChefVersion,
 		SandboxPath: SandboxPath,
 		RootPath:    RootPath,
+		Sudo:        flags.Sudo,
 	}
 	log.Debugf("Installer = %+v\n", installer)
 

--- a/provisioner/chefsolo/provisioner.go
+++ b/provisioner/chefsolo/provisioner.go
@@ -20,14 +20,13 @@ const (
 
 // Provisioner is a provisioner based on Chef Solo.
 type Provisioner struct {
-	RunList    []string
-	Attributes string
-	Format     string
-	LogLevel   string
-	UseSudo    bool
-
+	RunList     []string
+	Attributes  string
+	Format      string
+	LogLevel    string
 	SandboxPath string
 	RootPath    string
+	Sudo        bool
 }
 
 func (p Provisioner) prepareJSON() error {
@@ -52,13 +51,6 @@ func (p Provisioner) PrepareFiles() error {
 		return err
 	}
 	return p.prepareSoloConfig()
-}
-
-func (p Provisioner) sudo(args []string) []string {
-	if !p.UseSudo {
-		return args
-	}
-	return append([]string{"sudo"}, args...)
 }
 
 // Command returns the command string which will invoke the provisioner on the
@@ -86,5 +78,8 @@ func (p Provisioner) Command() []string {
 		cmd = append(cmd, "--override-runlist", strings.Join(p.RunList, ","))
 	}
 
-	return p.sudo(cmd)
+	if !p.Sudo {
+		return cmd
+	}
+	return append([]string{"sudo"}, cmd...)
 }

--- a/provisioner/chefsolo/provisioner_test.go
+++ b/provisioner/chefsolo/provisioner_test.go
@@ -142,7 +142,7 @@ var commandTests = []struct {
 	{
 		Provisioner{
 			RunList:     []string{"cats::foo"},
-			UseSudo:     true,
+			Sudo:        true,
 			SandboxPath: ".chef-runner/sandbox",
 			RootPath:    "/tmp/chef-runner",
 		},


### PR DESCRIPTION
Add `--sudo=false` option to not run commands using `sudo`. This currently affects Omnibus installer and Chef itself.
